### PR TITLE
Centred the JFrame on the screen

### DIFF
--- a/src/SweeperOfMine.java
+++ b/src/SweeperOfMine.java
@@ -17,7 +17,8 @@ public class SweeperOfMine {
 		frame.setResizable(false);
 		
 		frame.add(view);
-		
+
+		frame.setLocationRelativeTo(null);
 		frame.setVisible(true);
 	}
 


### PR DESCRIPTION
One line change mentioned in #2. The JFrame is centred on the screen now when it's launched:

![minesweeper-centred](https://user-images.githubusercontent.com/26788109/103446693-650cf080-4c7a-11eb-9d3e-e15565bad030.png)
